### PR TITLE
fix: TextField maxLength removed

### DIFF
--- a/lib/otp_field_v2.dart
+++ b/lib/otp_field_v2.dart
@@ -206,7 +206,6 @@ class OTPTextFieldV2State extends State<OTPTextFieldV2> {
         textAlign: TextAlign.center,
         style: widget.style,
         inputFormatters: widget.inputFormatter,
-        maxLength: 1,
         autofocus: index == 0 && widget.autoFocus,
         focusNode: _focusNodes[index],
         obscureText: widget.obscureText,


### PR DESCRIPTION
When you try to paste text into any input, only the first character is detected and the void _handlePaste(String str) function is never called.